### PR TITLE
Update error_metrics.R

### DIFF
--- a/cpt.cov/R/error_metrics.R
+++ b/cpt.cov/R/error_metrics.R
@@ -3,7 +3,7 @@ detection.rates = function(cpts.est, cpts.true, detect.interval){
     cpts = cross2(cpts.est, cpts.true)
     cpts = discard(cpts, ~abs(.x[[1]] - .x[[2]]) > detect.interval)
     correct.locs = unique(map_dbl(cpts, ~.x[[2]]))
-    tdr = 0; fdr=1;
+    tdr = 0; fdr=0;
     if(length(cpts.true)>0 & length(correct.locs)>0){
             tdr = length(correct.locs)/length(cpts.true)
     }


### PR DESCRIPTION
Changed default FDR to be 0 rather than previous value of 1.  This is because if cpts.est is null then previously it was reporting FDR=1 when it should be 0.